### PR TITLE
fix: pin shell fork revision to installed Caelestia version

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,9 @@ git pull
 bash patch.sh
 ```
 
-This re-applies the patch on top of whatever version of Caelestia is currently supported.
-Current v1.1.3 of Caelestia-AW patches Caelestia-2.2.0.
+This re-applies the patch on top of a compatible version of Caelestia. Caelestia-AW currently targets Caelestia 2.2.0.
+
+The installer detects the installed caelestia-shell version and checks out the matching shell fork revision before changing any files. It exits cleanly when the installed version is not supported, leaving the system untouched.
 
 > **Note:** Updates to Caelestia-AW may be delayed from upstream Caelestia by a few or several days due to unforeseen compatibility issues. If you update vanilla Caelestia and something breaks, re-running `patch.sh` from the latest Caelestia-AW will resolve it.
 

--- a/patch.sh
+++ b/patch.sh
@@ -77,9 +77,7 @@ select_shell_ref() {
         exit 1
     fi
 
-    local installed_version
-    installed_version="$(pacman -Q caelestia-shell | awk '{print $2}' | sed -E 's/-[0-9]+$//')"
-
+    installed_version="$(pacman -Q caelestia-shell | awk '{print $2}' | sed -E 's/^[0-9]+://; s/-[0-9]+$//')"
     case "$installed_version" in
         2.2.0)
             SHELL_REF="ecb72651321657cfa14571489f161e7bf7fc8422"

--- a/patch.sh
+++ b/patch.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 # CONFIG
 SHELL_REPO="https://github.com/AdiAmbassador/caelestia-shell-aw.git"
 CLI_REPO="https://github.com/AdiAmbassador/caelestia-cli-aw.git"
+SHELL_REF=""
 
 SHELL_DEST="/etc/xdg/quickshell/caelestia"
 CLI_DEST="$(python3 -c 'import site; print(site.getsitepackages()[0])')/caelestia"
@@ -70,6 +71,27 @@ error() {
     echo -e "${RED}[✗]${RESET} $1"
 }
 
+select_shell_ref() {
+    if ! pacman -Q caelestia-shell >/dev/null 2>&1; then
+        error "caelestia-shell is not installed. Install Caelestia before applying this patch."
+        exit 1
+    fi
+
+    local installed_version
+    installed_version="$(pacman -Q caelestia-shell | awk '{print $2}' | sed -E 's/-[0-9]+$//')"
+
+    case "$installed_version" in
+        2.2.0)
+            SHELL_REF="ecb72651321657cfa14571489f161e7bf7fc8422"
+            ;;
+        *)
+            error "Unsupported caelestia-shell version: ${installed_version}."
+            echo -e "${YELLOW}Supported version: 2.2.0.${RESET}"
+            exit 1
+            ;;
+    esac
+}
+
 run_step() {
     local msg=$1
     shift
@@ -114,10 +136,15 @@ header
 echo -e "${MAGENTA}Starting installation of Caelestia Animated Wallpaper patches...${RESET}"
 echo
 
+select_shell_ref
+
 # Clone repo
 log "Cloning online shell fork..."
-git clone --depth 1 "$SHELL_REPO" /tmp/caelestia-shell-fork >/dev/null 2>>"$LOG_FILE" &
+git clone "$SHELL_REPO" /tmp/caelestia-shell-fork >/dev/null 2>>"$LOG_FILE" &
 spinner $! "Cloning shell repo"
+echo
+
+run_step "Checked out compatible shell revision" git -C /tmp/caelestia-shell-fork checkout --detach "$SHELL_REF"
 echo
 
 log "Cloning online CLI fork..."


### PR DESCRIPTION
caelestia-shell-aw/main tracks the upstream 2.3 code base, while the
caelestia-shell package in the AUR is still 2.2.0. patch.sh clones the
latest shell-aw and copies 2.3 UI code over a 2.2 install, breaking
the bar, sidebar and nexus pages.

## reproduction
- fresh caelestia 2.2.0-1 install from AUR
- `git clone https://github.com/AdiAmbassador/caelestia-aw.git`
- `bash patch.sh`

## changes
- detect the installed caelestia-shell version via pacman
- check out the compatible shell-aw revision (ecb7265) before copying any files
- unsupported versions abort cleanly without touching the system
- full clone instead of `--depth 1`, since the pinned revision predates HEAD

## verification
Tested with caelestia-shell 2.2.0-1: patch applies, shell starts, bar/sidebar render.

## follow-up
When the caelestia-shell package is bumped to 2.3.0 in the AUR, add a
case for it with the then-current shell-aw revision and test before
relying on it. Until then the `*` case is the safety net.
